### PR TITLE
Missing test: Update RdfKernelTestBase and the dependant tests

### DIFF
--- a/modules/rdf_taxonomy/tests/src/Kernel/SparqlTaxonomyTest.php
+++ b/modules/rdf_taxonomy/tests/src/Kernel/SparqlTaxonomyTest.php
@@ -4,7 +4,7 @@ namespace Drupal\rdf_taxonomy\Tests;
 
 use Drupal\rdf_entity\Entity\Rdf;
 use Drupal\taxonomy\Entity\Term;
-use Drupal\Tests\joinup_core\Kernel\JoinupKernelTestBase;
+use Drupal\Tests\rdf_entity\Kernel\RdfKernelTestBase;
 
 /**
  * Tests Entity Query functionality of the Sparql backend.
@@ -13,7 +13,7 @@ use Drupal\Tests\joinup_core\Kernel\JoinupKernelTestBase;
  *
  * @group Entity
  */
-class SparqlTaxonomyTest extends JoinupKernelTestBase {
+class SparqlTaxonomyTest extends RdfKernelTestBase {
 
   /**
    * Modules to enable.

--- a/tests/src/Kernel/RdfEncodingTest.php
+++ b/tests/src/Kernel/RdfEncodingTest.php
@@ -3,14 +3,13 @@
 namespace Drupal\Tests\rdf_entity\Kernel;
 
 use Drupal\rdf_entity\Entity\Rdf;
-use Drupal\Tests\joinup_core\Kernel\JoinupKernelTestBase;
 
 /**
  * Tests the support of saving various encoded stings in the triple store.
  *
  * @group rdf_entity
  */
-class RdfEncodingTest extends JoinupKernelTestBase {
+class RdfEncodingTest extends RdfKernelTestBase {
 
   /**
    * Test that naughty strings can safely be saved to the database.

--- a/tests/src/Kernel/RdfEntityCacheTest.php
+++ b/tests/src/Kernel/RdfEntityCacheTest.php
@@ -4,14 +4,13 @@ namespace Drupal\Tests\rdf_entity\Kernel;
 
 use Drupal\Core\Cache\Cache;
 use Drupal\rdf_entity\Entity\Rdf;
-use Drupal\Tests\joinup_core\Kernel\JoinupKernelTestBase;
 
 /**
  * Tests RDF entity caching.
  *
  * @group rdf_entity
  */
-class RdfEntityCacheTest extends JoinupKernelTestBase {
+class RdfEntityCacheTest extends RdfKernelTestBase {
 
   /**
    * Tests RDF entity cache tags.

--- a/tests/src/Kernel/RdfEntityCreationTest.php
+++ b/tests/src/Kernel/RdfEntityCreationTest.php
@@ -4,7 +4,6 @@ namespace Drupal\Tests\rdf_entity\Kernel;
 
 use Drupal\rdf_entity\Entity\Rdf;
 use Drupal\rdf_entity\Exception\DuplicatedIdException;
-use Drupal\Tests\joinup_core\Kernel\JoinupKernelTestBase;
 
 /**
  * Provides unit testing for the 'rdf_entity' entity.
@@ -13,7 +12,7 @@ use Drupal\Tests\joinup_core\Kernel\JoinupKernelTestBase;
  *
  * @group rdf_entity
  */
-class RdfEntityCreationTest extends JoinupKernelTestBase {
+class RdfEntityCreationTest extends RdfKernelTestBase {
 
   /**
    * Tests overlapping IDs.

--- a/tests/src/Kernel/RdfEntityLanguageTestBase.php
+++ b/tests/src/Kernel/RdfEntityLanguageTestBase.php
@@ -52,8 +52,6 @@ abstract class RdfEntityLanguageTestBase extends RdfKernelTestBase {
   protected function setUp() {
     parent::setUp();
 
-    $this->installEntitySchema('user');
-    $this->installConfig(['rdf_entity_test']);
     $this->languageManager = $this->container->get('language_manager');
     $this->installConfig(['language']);
     // Enable translations for the rdf entity.

--- a/tests/src/Kernel/RdfKernelTestBase.php
+++ b/tests/src/Kernel/RdfKernelTestBase.php
@@ -8,7 +8,18 @@ use Drupal\Tests\rdf_entity\Traits\RdfDatabaseConnectionTrait;
 /**
  * A base class for the rdf tests.
  *
- * Sets up the SPARQL database connection.
+ * Mainly, assures the connection to the triple store database.
+ *
+ * IMPORTANT! You should not use real RDF entity bundles for testing because the
+ * test is using the same backend storage as the main site and you can end up
+ * with changes to the main site content. Create your own RDF entity bundles for
+ * testing purposes, like the one provided in the rdf_entity_test.module. That
+ * module uses a dedicated testing graphs, (http://example.com/dummy/published
+ * and http://example.com/dummy/draft). This base class enables, at startup, the
+ * rdf_entity_test.module and takes care of deleting testing data. For other
+ * custom testing data that you are adding for testing, you should take care of
+ * cleaning it after the test. You can extend the tearDown() method for this
+ * purpose.
  */
 abstract class RdfKernelTestBase extends EntityKernelTestBase {
 
@@ -20,8 +31,9 @@ abstract class RdfKernelTestBase extends EntityKernelTestBase {
    * @var string[]
    */
   public static $modules = [
-    'ds',
     'comment',
+    'datetime',
+    'rdf_entity_test',
   ];
 
   /**
@@ -35,6 +47,34 @@ abstract class RdfKernelTestBase extends EntityKernelTestBase {
     $this->installModule('rdf_draft');
     $this->installConfig(['rdf_entity', 'rdf_draft']);
     $this->installEntitySchema('rdf_entity');
+    $this->installEntitySchema('user');
+    $this->installConfig(['rdf_entity_test']);
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function tearDown() {
+    // Delete all data produced by testing module.
+    foreach (['dummy', 'with_owner', 'multifield'] as $bundle) {
+      foreach (['published', 'draft'] as $graph) {
+        $query = <<<EndOfQuery
+DELETE {
+  GRAPH <http://example.com/$bundle/$graph> {
+    ?entity ?field ?value
+  }
+}
+WHERE {
+  GRAPH <http://example.com/$bundle/$graph> {
+    ?entity ?field ?value
+  }
+}
+EndOfQuery;
+        $this->sparql->query($query);
+      }
+    }
+
+    parent::tearDown();
   }
 
 }

--- a/tests/src/Kernel/RdfOwnerTest.php
+++ b/tests/src/Kernel/RdfOwnerTest.php
@@ -3,14 +3,13 @@
 namespace Drupal\Tests\rdf_entity\Kernel;
 
 use Drupal\rdf_entity\Entity\Rdf;
-use Drupal\Tests\joinup_core\Kernel\JoinupKernelTestBase;
 
 /**
  * Tests rdf_entity owner functionality.
  *
  * @group rdf_entity
  */
-class RdfOwnerTest extends JoinupKernelTestBase {
+class RdfOwnerTest extends RdfKernelTestBase {
 
   /**
    * Tests rdf_entity owner functionality.

--- a/tests/src/Kernel/RdfQueryExceptionTest.php
+++ b/tests/src/Kernel/RdfQueryExceptionTest.php
@@ -3,14 +3,13 @@
 namespace Drupal\Tests\rdf_entity\Kernel;
 
 use Drupal\rdf_entity\Exception\SparqlQueryException;
-use Drupal\Tests\joinup_core\Kernel\JoinupKernelTestBase;
 
 /**
  * Test that a proper exception is thrown when a query fails.
  *
  * @group rdf_entity
  */
-class RdfQueryExceptionTest extends JoinupKernelTestBase {
+class RdfQueryExceptionTest extends RdfKernelTestBase {
 
   /**
    * Exception with query in message thrown for selects.

--- a/tests/src/Kernel/SparqlEntityInsertTest.php
+++ b/tests/src/Kernel/SparqlEntityInsertTest.php
@@ -5,14 +5,14 @@ namespace Drupal\KernelTests\Core\Entity;
 use Drupal\Component\Utility\Random;
 use Drupal\rdf_entity\Entity\Rdf;
 use Drupal\rdf_entity\RdfInterface;
-use Drupal\Tests\joinup_core\Kernel\JoinupKernelTestBase;
+use Drupal\Tests\rdf_entity\Kernel\RdfKernelTestBase;
 
 /**
  * Tests Entity Query functionality of the Sparql backend.
  *
  * @group Entity
  */
-class SparqlEntityInsertTest extends JoinupKernelTestBase {
+class SparqlEntityInsertTest extends RdfKernelTestBase {
 
   /**
    * Modules to enable.

--- a/tests/src/Kernel/SparqlEntityQueryTest.php
+++ b/tests/src/Kernel/SparqlEntityQueryTest.php
@@ -3,7 +3,7 @@
 namespace Drupal\rdf_entity\Tests;
 
 use Drupal\rdf_entity\Entity\Rdf;
-use Drupal\Tests\joinup_core\Kernel\JoinupKernelTestBase;
+use Drupal\Tests\rdf_entity\Kernel\RdfKernelTestBase;
 
 /**
  * Tests Entity Query functionality of the Sparql backend.
@@ -12,7 +12,7 @@ use Drupal\Tests\joinup_core\Kernel\JoinupKernelTestBase;
  *
  * @group Entity
  */
-class SparqlEntityQueryTest extends JoinupKernelTestBase {
+class SparqlEntityQueryTest extends RdfKernelTestBase {
 
   /**
    * Modules to enable.


### PR DESCRIPTION
In our project we have wrongly created a kernel test base outside the rdf_entity module and almost all kernel tests in rdf_entity were depending on it.

This PR fixes this by taking out the code from the other project and updating the RdfKernelTestBase class. The rest of the tests are updated accordingly. All tests were run in order to validate these changes.