### PR TITLE
Id string comparison

### DIFF
--- a/src/Entity/Query/Sparql/SparqlCondition.php
+++ b/src/Entity/Query/Sparql/SparqlCondition.php
@@ -794,7 +794,8 @@ class SparqlCondition extends ConditionFundamentals implements ConditionInterfac
       if (is_array($value)) {
         return SparqlArg::toResourceUris($value);
       }
-      // Convert the value to sting in order to perform the rest of comparisons.
+      // Convert the value to a string in order to perform the remaining
+      // comparisons.
       elseif (is_string($value)) {
         return 'STR("' . $value . '")';
       }

--- a/tests/src/Kernel/SparqlEntityQueryTest.php
+++ b/tests/src/Kernel/SparqlEntityQueryTest.php
@@ -460,6 +460,74 @@ class SparqlEntityQueryTest extends JoinupKernelTestBase {
   }
 
   /**
+   * Tests operators '<', '>', '<=', '>=' for Ids.
+   *
+   * @dataProvider idStringComparisonDataProvider
+   */
+  public function testIdStringComparison($value, $operator, $expected_results) {
+    $query = $this->factory->get('rdf_entity');
+    $query->condition('id', $value, $operator);
+    $this->queryResults = $query->sort('id')->execute();
+    $this->assertResult($expected_results);
+  }
+
+  /**
+   * Data provider for testIdStringComparison test.
+   */
+  public function idStringComparisonDataProvider() {
+    return [
+      [
+        'http://dummy.example.com/002',
+        '<',
+        ['http://dummy.example.com/001'],
+      ],
+      [
+        'http://dummy.example.com/002',
+        '<=',
+        ['http://dummy.example.com/001', 'http://dummy.example.com/002'],
+      ],
+      [
+        'http://dummy.example.com/009',
+        '>',
+        // The multifield bundle entities have an id starting with 'http://m'
+        // which is sorted after the 'http://d' so all entities of the
+        // multifield bundled are also returned for the '>' and '>=' operators.
+        [
+          'http://dummy.example.com/010',
+          'http://multifield.example.com/001',
+          'http://multifield.example.com/002',
+          'http://multifield.example.com/003',
+          'http://multifield.example.com/004',
+          'http://multifield.example.com/005',
+          'http://multifield.example.com/006',
+          'http://multifield.example.com/007',
+          'http://multifield.example.com/008',
+          'http://multifield.example.com/009',
+          'http://multifield.example.com/010',
+        ],
+      ],
+      [
+        'http://dummy.example.com/009',
+        '>=',
+        [
+          'http://dummy.example.com/009',
+          'http://dummy.example.com/010',
+          'http://multifield.example.com/001',
+          'http://multifield.example.com/002',
+          'http://multifield.example.com/003',
+          'http://multifield.example.com/004',
+          'http://multifield.example.com/005',
+          'http://multifield.example.com/006',
+          'http://multifield.example.com/007',
+          'http://multifield.example.com/008',
+          'http://multifield.example.com/009',
+          'http://multifield.example.com/010',
+        ],
+      ],
+    ];
+  }
+
+  /**
    * Asserts that arrays are identical.
    */
   protected function assertResult() {


### PR DESCRIPTION
As the branch name declares, this PR is to support the operators '<', '>', '<=', '>=' for the id field.

*Disclaimer:*
The process of comparing and sorting per id was already supported. What is added here is the option to filter by id greater(or equal)/less(or equal) than some string. This process is very slow and not recommended if it can be avoided. In a very basic test I did the following:
```
SELECT ?a ?b ?c
WHERE {
  ?a ?b ?c
}
LIMIT 100
```
Process time: 86 ms.

```
SELECT ?a ?b ?c
WHERE {
  ?a ?b ?c .
  FILTER (STR(?a) < STR(<http://a))
}
LIMIT 100
```
Process time: 646 ms.

Still, I also added tests for all that matters.