### PR TITLE
Allow easy creation of graph store objects

### DIFF
--- a/src/RdfEntityGraphStoreTrait.php
+++ b/src/RdfEntityGraphStoreTrait.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace Drupal\rdf_entity;
+
+use Drupal\Core\Database\Database;
+use EasyRdf\GraphStore;
+
+/**
+ * Provides helper methods for graph stores on the current SPARQL connection.
+ */
+trait RdfEntityGraphStoreTrait {
+
+  /**
+   * Creates a new Graph Store object using the SPARQL connection.
+   *
+   * @return \EasyRdf\GraphStore
+   *   The new graph store object.
+   */
+  protected function createGraphStore(): GraphStore {
+    $sparql_connection = Database::getConnection('default', 'sparql_default');
+    $connection_options = $sparql_connection->getConnectionOptions();
+    $connect_string = "http://{$connection_options['host']}:{$connection_options['port']}/sparql-graph-crud";
+    // Use a local SPARQL 1.1 Graph Store.
+    return new GraphStore($connect_string);
+  }
+
+}


### PR DESCRIPTION
This PR adds a trait with reusable code that allows to quickly create a GraphStore object on the main SPARQL connection.