### PR TITLE
Add support for the xsd:anyURI format.

### DIFF
--- a/src/RdfFieldHandler.php
+++ b/src/RdfFieldHandler.php
@@ -686,6 +686,7 @@ class RdfFieldHandler {
       'xsd:dateTime' => t('Datetime'),
       'xsd:decimal' => t('Decimal'),
       'xsd:integer' => t('Integer'),
+      'xsd:anyURI' => t('URI (xsd:anyURI)'),
     ];
   }
 


### PR DESCRIPTION
As noted, this simply adds support for an extra type, the `xsd:anyURI` format.

Please note, that no other changes are needed as the easyrdf library that the module is using, already handles this format by default.

As a future reference, if I am not mistaking, all xsd base types are handled by default.