### PR TITLE
Modernise the SPARQL entity query, fix some field handler issues and allow Rdf entity static loaders to pass graphs

### DIFF
--- a/API.md
+++ b/API.md
@@ -94,6 +94,6 @@ $storage = \Drupal::entityTypeManager()->getStorage('food');
 $query = $storage->getQuery;
 $ids = $query
   ->condition('type', 'fruit')
-  ->setGraphType(['default', 'draft'])
+  ->graphs(['default', 'draft'])
   ->execute();
 ```

--- a/modules/rdf_draft/README.md
+++ b/modules/rdf_draft/README.md
@@ -79,15 +79,15 @@ $query = \Drupal::service('entity_type.manager')
 To further filter by graph, it is enough to call the
 
 ```
-$query->setGraphType(['default', 'draft']);
+$query->graphs(['default', 'draft']);
 ```
 This is where the filter applies. You cannot currently filter by the
 `condition()` method.
 
 NOTICE: The results will have only one graph per entity and this will be the
-first available graph. With the `setGraphType()` method, you set the priority,
+first available graph. With the `graphs()` method, you set the priority,
 not the list of graphs to retrieve from. Also, all loaded entities will be
-affected by the priority provided in the setGraphType. If you want to set the
+affected by the priority provided in the `graphs` method. If you want to set the
 priority only for a specific entity, given that you have the id of this entity,
 you can do it by setting the priority to the GraphHandler service itself through
 the storage class.
@@ -108,7 +108,7 @@ This is because multiple entities can be loaded in a single request or the same
 entity can be loaded more than once. This means that we cannot have a global
 priority, nor reset the priority after the entity is loaded.
 
-The difference with the `$query->setGraphType()` above, is that the query saves
+The difference with the `$query->graphs()` above, is that the query saves
 the graph locally for the query. That means that all loaded entities are
 affected by it. For entities that do not have a specific set of graphs in the
 query, the normal priority is being used (first from the 'default' graph and

--- a/src/Entity/Controller/RdfListBuilder.php
+++ b/src/Entity/Controller/RdfListBuilder.php
@@ -73,11 +73,8 @@ class RdfListBuilder extends EntityListBuilder {
       $definitions = $rdf_storage->getGraphDefinitions();
       if (isset($definitions[$graph])) {
         // Use the graph to build the list.
-        $query->setGraphType([$graph]);
+        $query->graphs([$graph]);
       }
-    }
-    else {
-      $query->setGraphType($rdf_storage->getGraphHandler()->getEntityTypeGraphIds($rdf_storage->getEntityTypeId()));
     }
 
     if ($rid = $request->get('rid') ?: NULL) {

--- a/src/Entity/Query/Sparql/Query.php
+++ b/src/Entity/Query/Sparql/Query.php
@@ -199,7 +199,7 @@ class Query extends QueryBase implements SparqlQueryInterface {
 
     if (!$this->graphIds) {
       // If no graph IDs were requested, allow all graphs that Drupal is aware
-      // of given this entity type.
+      // for this entity type.
       $this->graphIds = $this->graphHandler->getEntityTypeGraphIds($this->getEntityTypeId());
     }
     $graph_uris = $this->graphHandler->getEntityTypeGraphUrisFlatList($this->getEntityTypeId(), $this->graphIds);

--- a/src/Entity/Query/Sparql/SparqlCondition.php
+++ b/src/Entity/Query/Sparql/SparqlCondition.php
@@ -198,7 +198,7 @@ class SparqlCondition extends ConditionFundamentals implements ConditionInterfac
   /**
    * {@inheritdoc}
    */
-  public function __construct($conjunction, QueryInterface $query, array $namespaces, RdfGraphHandlerInterface $rdf_graph_handler, RdfFieldHandler $rdf_field_handler) {
+  public function __construct($conjunction, SparqlQueryInterface $query, array $namespaces, RdfGraphHandlerInterface $rdf_graph_handler, RdfFieldHandler $rdf_field_handler) {
     $conjunction = strtoupper($conjunction);
     parent::__construct($conjunction, $query, $namespaces);
     $this->graphHandler = $rdf_graph_handler;

--- a/src/Entity/Query/Sparql/SparqlQueryInterface.php
+++ b/src/Entity/Query/Sparql/SparqlQueryInterface.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace Drupal\rdf_entity\Entity\Query\Sparql;
+
+use Drupal\Core\Entity\EntityTypeInterface;
+use Drupal\Core\Entity\Query\QueryInterface;
+use Drupal\rdf_entity\RdfEntitySparqlStorageInterface;
+
+/**
+ * Provides an interface for SPARQL entity queries.
+ */
+interface SparqlQueryInterface extends QueryInterface {
+
+  /**
+   * Sets the IDs of the graph to be queried.
+   *
+   * If this method is not called, the default graphs for this entity type are
+   * used. Calling the method with no argument will remove any filtering of RDF
+   * entities on graphs and the query will return all entities from all graphs
+   * that are known by Drupal for this entity type.
+   *
+   * @param string[]|null $graph_ids
+   *   (optional) A list of graph IDs to filter on. If omitted, the query will
+   *   return all entities from all graphs that are known by Drupal for this
+   *   entity type.
+   *
+   * @return $this
+   */
+  public function graphs(array $graph_ids = NULL): self;
+
+  /**
+   * Returns the entity type.
+   *
+   * @return \Drupal\Core\Entity\EntityTypeInterface
+   *   The entity type object.
+   */
+  public function getEntityType(): EntityTypeInterface;
+
+  /**
+   * Returns the entity type storage.
+   *
+   * @return \Drupal\rdf_entity\RdfEntitySparqlStorageInterface
+   *   The entity type storage.
+   */
+  public function getEntityStorage(): RdfEntitySparqlStorageInterface;
+
+}

--- a/src/Entity/Rdf.php
+++ b/src/Entity/Rdf.php
@@ -378,6 +378,28 @@ class Rdf extends ContentEntityBase implements RdfInterface {
   }
 
   /**
+   * {@inheritdoc}
+   */
+  public static function load($id, array $graph_ids = NULL) {
+    $entity_type_repository = \Drupal::service('entity_type.repository');
+    $entity_type_manager = \Drupal::entityTypeManager();
+    /** @var \Drupal\rdf_entity\RdfEntitySparqlStorageInterface $storage */
+    $storage = $entity_type_manager->getStorage($entity_type_repository->getEntityTypeFromClass(get_called_class()));
+    return $storage->load($id, $graph_ids);
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function loadMultiple(array $ids = NULL, array $graph_ids = NULL) {
+    $entity_type_repository = \Drupal::service('entity_type.repository');
+    $entity_type_manager = \Drupal::entityTypeManager();
+    /** @var \Drupal\rdf_entity\RdfEntitySparqlStorageInterface $storage */
+    $storage = $entity_type_manager->getStorage($entity_type_repository->getEntityTypeFromClass(get_called_class()));
+    return $storage->loadMultiple($ids, $graph_ids);
+  }
+
+  /**
    * Returns whether the entity bundle has mapping for a certain field column.
    *
    * @param string $field_name

--- a/src/Entity/RdfEntitySparqlStorage.php
+++ b/src/Entity/RdfEntitySparqlStorage.php
@@ -640,10 +640,10 @@ QUERY;
       unset($values[$uuid_key]);
     }
 
-    /** @var \Drupal\rdf_entity\Entity\Query\Sparql\Query $query */
-    $query = $this->getQuery();
-    $query->setGraphType($graph_ids);
-    $query->accessCheck(FALSE);
+    /** @var \Drupal\rdf_entity\Entity\Query\Sparql\SparqlQueryInterface $query */
+    $query = $this->getQuery()
+      ->graphs($graph_ids)
+      ->accessCheck(FALSE);
     $this->buildPropertyQuery($query, $values);
     $result = $query->execute();
 
@@ -746,31 +746,6 @@ QUERY;
    */
   protected function getQueryServiceName() {
     return 'entity.query.sparql';
-  }
-
-  /**
-   * {@inheritdoc}
-   */
-  public function getQuery($conjunction = 'AND') {
-    // Access the service directly rather than entity.query factory so the
-    // storage's current entity type is used.
-    /** @var \Drupal\rdf_entity\Entity\Query\Sparql\Query $query */
-    $query = \Drupal::service($this->getQueryServiceName())->get($this->entityType, $conjunction, $this->graphHandler, $this->fieldHandler);
-
-    /*
-     * When the storage class supports the notion of a 'published state' by
-     * implementing the published interface, we then have to determine if
-     * drafting has been enabled for this entity type (rdf_draft module). If so,
-     * the 'draft' graph will hold the unpublished versions, 'default' graph
-     * contains the published entities.
-     */
-    if (in_array(EntityPublishedInterface::class, class_implements($this->entityClass))) {
-      if ($this->moduleHandler->moduleExists('rdf_draft')) {
-        $query->setGraphType($this->getGraphHandler()->getEntityTypeGraphIds($this->getEntityTypeId()));
-      }
-    }
-
-    return $query;
   }
 
   /**

--- a/src/Exception/UnmappedFieldException.php
+++ b/src/Exception/UnmappedFieldException.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace Drupal\rdf_entity\Exception;
+
+/**
+ * Thrown when an unmapped field is requested.
+ */
+class UnmappedFieldException extends \Exception {}

--- a/src/Plugin/pathauto/AliasType/RdfEntityAliasType.php
+++ b/src/Plugin/pathauto/AliasType/RdfEntityAliasType.php
@@ -122,17 +122,13 @@ class RdfEntityAliasType extends EntityAliasTypeBase implements ContainerFactory
   /**
    * Returns a Query object for RDF entities.
    *
-   * @return \Drupal\rdf_entity\Entity\Query\Sparql\Query
+   * @return \Drupal\Core\Entity\Query\QueryInterface
    *   The entity query.
    */
   protected function getRdfEntityQuery() : Query {
-    /** @var \Drupal\rdf_entity\Entity\RdfEntitySparqlStorage $storage */
+    /** @var \Drupal\rdf_entity\RdfEntitySparqlStorageInterface $storage */
     $storage = $this->entityTypeManager->getStorage('rdf_entity');
-    /** @var \Drupal\rdf_entity\Entity\Query\Sparql\Query $query */
-    $query = $storage->getQuery();
-    $query->setGraphType($storage->getGraphHandler()->getEntityTypeGraphIds('rdf_entity'));
-
-    return $query;
+    return $storage->getQuery();
   }
 
   /**

--- a/src/RdfFieldHandler.php
+++ b/src/RdfFieldHandler.php
@@ -11,6 +11,7 @@ use Drupal\rdf_entity\Event\InboundValueEvent;
 use Drupal\rdf_entity\Event\OutboundValueEvent;
 use Drupal\rdf_entity\Event\RdfEntityEvents;
 use Drupal\rdf_entity\Exception\NonExistingFieldPropertyException;
+use Drupal\rdf_entity\Exception\UnmappedFieldException;
 use EasyRdf\Literal;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 
@@ -220,7 +221,7 @@ class RdfFieldHandler {
   public function getFieldPredicates($entity_type_id, $field, $column = NULL, $bundle = NULL) {
     $drupal_to_sparql = $this->getOutboundMap($entity_type_id);
     if (!isset($drupal_to_sparql['fields'][$field])) {
-      throw new \Exception("You are requesting the mapping for a non mapped field: $field.");
+      throw new UnmappedFieldException("You are requesting the mapping for a non mapped field: $field.");
     }
     $field_mapping = $drupal_to_sparql['fields'][$field];
     $column = $column ?: $field_mapping['main_property'];

--- a/src/RdfFieldHandler.php
+++ b/src/RdfFieldHandler.php
@@ -233,7 +233,7 @@ class RdfFieldHandler {
         $return[$bundle] = $field_mapping['columns'][$column][$bundle]['predicate'];
       }
     }
-    return array_unique(array_filter($return));
+    return array_filter($return);
   }
 
   /**

--- a/src/RdfFieldHandler.php
+++ b/src/RdfFieldHandler.php
@@ -215,8 +215,8 @@ class RdfFieldHandler {
    * @return array
    *   An array of predicates.
    *
-   * @throws \Exception
-   *    Thrown when a non existing field is requested.
+   * @throws \Drupal\rdf_entity\Exception\UnmappedFieldException
+   *    Thrown when a unmapped field is requested.
    */
   public function getFieldPredicates($entity_type_id, $field, $column = NULL, $bundle = NULL) {
     $drupal_to_sparql = $this->getOutboundMap($entity_type_id);


### PR DESCRIPTION
Contains:
* Modernise the SPQRQL entity query by adding a `SparqlQueryInterface` interface and replaced the method allowing filtering on graphs with a chained one.
* Allow `Rdf` entity to pass the graph candidates to its static loaders.
* Fix a bug in `RdfFieldHandler` that has removed valid entries from the `::getFieldPredicates()` result.
* Throw a specialised exception for unmapped fields in `RdfFieldHandler::getFieldPredicates()`, allowing to be catched from the caller.