### PR TITLE
RdfFieldHandler is not aware about fields defined via hook_entity_bundle_field_info()

### DIFF
--- a/modules/rdf_draft/tests/src/Kernel/RdfDraftGraphTest.php
+++ b/modules/rdf_draft/tests/src/Kernel/RdfDraftGraphTest.php
@@ -99,7 +99,7 @@ class RdfDraftGraphTest extends KernelTestBase {
     $apple = $storage->load($id, ['invalid graph', 'default', 'draft']);
 
     // Delete the draft version.
-    $storage->deleteFromGraph($apple->id(), 'draft');
+    $storage->deleteFromGraph([$apple], 'draft');
     $this->assertNull($storage->load($id, ['draft']));
     $this->assertNotNull($storage->load($id, ['default']));
     $this->assertNotNull($storage->load($id, ['arbitrary']));

--- a/rdf_entity.module
+++ b/rdf_entity.module
@@ -107,7 +107,7 @@ function rdf_entity_form_field_storage_config_edit_form_alter(&$form, FormStateI
     $form['rdf_mapping'][$column]['format_' . $column] = [
       '#type' => 'select',
       '#title' => t('Value format'),
-      '#options' => RdfFieldHandler::getSupportedDatatypes(),
+      '#options' => RdfFieldHandler::getSupportedDataTypes(),
       '#empty_value' => 'no_format',
       '#weight' => 151,
       '#default_value' => isset($settings['format']) ? $settings['format'] : NULL,
@@ -281,7 +281,7 @@ function rdf_entity_form_alter(&$form, FormStateInterface $form_state) {
         '#type' => 'select',
         '#title' => t('Value format'),
         '#description' => t('The rdf format. Required if format is filled.'),
-        '#options' => RdfFieldHandler::getSupportedDatatypes(),
+        '#options' => RdfFieldHandler::getSupportedDataTypes(),
         '#empty_value' => '',
         '#weight' => 151,
         '#default_value' => $mapping->getMapping($field_name, $column_name)['format'] ?? NULL,

--- a/src/Entity/Query/Sparql/Query.php
+++ b/src/Entity/Query/Sparql/Query.php
@@ -10,7 +10,7 @@ use Drupal\Core\Entity\Query\QueryBase;
 use Drupal\Core\Entity\Query\Sql\ConditionAggregate;
 use Drupal\rdf_entity\Database\Driver\sparql\Connection;
 use Drupal\rdf_entity\RdfEntitySparqlStorageInterface;
-use Drupal\rdf_entity\RdfFieldHandler;
+use Drupal\rdf_entity\RdfFieldHandlerInterface;
 use Drupal\rdf_entity\RdfGraphHandlerInterface;
 
 /**
@@ -79,7 +79,7 @@ class Query extends QueryBase implements SparqlQueryInterface {
   /**
    * The rdf mapping handler service object.
    *
-   * @var \Drupal\rdf_entity\RdfFieldHandler
+   * @var \Drupal\rdf_entity\RdfFieldHandlerInterface
    */
   protected $fieldHandler;
 
@@ -99,10 +99,10 @@ class Query extends QueryBase implements SparqlQueryInterface {
    *   The entity type manager service object.
    * @param \Drupal\rdf_entity\RdfGraphHandlerInterface $rdf_graph_handler
    *   The rdf graph handler service.
-   * @param \Drupal\rdf_entity\RdfFieldHandler $rdf_field_handler
+   * @param \Drupal\rdf_entity\RdfFieldHandlerInterface $rdf_field_handler
    *   The rdf mapping handler service.
    */
-  public function __construct(EntityTypeInterface $entity_type, $conjunction, Connection $connection, array $namespaces, EntityTypeManagerInterface $entity_type_manager, RdfGraphHandlerInterface $rdf_graph_handler, RdfFieldHandler $rdf_field_handler) {
+  public function __construct(EntityTypeInterface $entity_type, $conjunction, Connection $connection, array $namespaces, EntityTypeManagerInterface $entity_type_manager, RdfGraphHandlerInterface $rdf_graph_handler, RdfFieldHandlerInterface $rdf_field_handler) {
     // Assign the handlers before calling the parent so that they can be passed
     // to the condition class properly.
     $this->graphHandler = $rdf_graph_handler;

--- a/src/Entity/Query/Sparql/QueryFactory.php
+++ b/src/Entity/Query/Sparql/QueryFactory.php
@@ -7,7 +7,7 @@ use Drupal\Core\Entity\EntityTypeManagerInterface;
 use Drupal\Core\Entity\Query\QueryBase;
 use Drupal\Core\Entity\Query\QueryFactoryInterface;
 use Drupal\rdf_entity\Database\Driver\sparql\Connection;
-use Drupal\rdf_entity\RdfFieldHandler;
+use Drupal\rdf_entity\RdfFieldHandlerInterface;
 use Drupal\rdf_entity\RdfGraphHandlerInterface;
 
 /**
@@ -46,7 +46,7 @@ class QueryFactory implements QueryFactoryInterface {
   /**
    * The rdf mapping helper service object.
    *
-   * @var \Drupal\rdf_entity\RdfFieldHandler
+   * @var \Drupal\rdf_entity\RdfFieldHandlerInterface
    */
   protected $fieldHandler;
 
@@ -59,10 +59,10 @@ class QueryFactory implements QueryFactoryInterface {
    *   The entity type manager.
    * @param \Drupal\rdf_entity\RdfGraphHandlerInterface $rdf_graph_handler
    *   The rdf graph helper service.
-   * @param \Drupal\rdf_entity\RdfFieldHandler $rdf_field_handler
+   * @param \Drupal\rdf_entity\RdfFieldHandlerInterface $rdf_field_handler
    *   The rdf mapping helper service.
    */
-  public function __construct(Connection $connection, EntityTypeManagerInterface $entity_type_manager, RdfGraphHandlerInterface $rdf_graph_handler, RdfFieldHandler $rdf_field_handler) {
+  public function __construct(Connection $connection, EntityTypeManagerInterface $entity_type_manager, RdfGraphHandlerInterface $rdf_graph_handler, RdfFieldHandlerInterface $rdf_field_handler) {
     $this->connection = $connection;
     $this->namespaces = QueryBase::getNamespaces($this);
     $this->entityTypeManager = $entity_type_manager;

--- a/src/Entity/Query/Sparql/SparqlArg.php
+++ b/src/Entity/Query/Sparql/SparqlArg.php
@@ -3,7 +3,7 @@
 namespace Drupal\rdf_entity\Entity\Query\Sparql;
 
 use Drupal\Component\Utility\UrlHelper;
-use Drupal\rdf_entity\RdfFieldHandler;
+use Drupal\rdf_entity\RdfFieldHandlerInterface;
 use EasyRdf\Serialiser\Ntriples;
 
 /**
@@ -62,7 +62,7 @@ class SparqlArg {
     if (preg_match('/^<(.+)>$/', $uri) !== NULL) {
       $uri = trim($uri, '<>');
     }
-    return self::serialize($uri, RdfFieldHandler::RESOURCE);
+    return self::serialize($uri, RdfFieldHandlerInterface::RESOURCE);
   }
 
   /**
@@ -116,15 +116,15 @@ class SparqlArg {
   public static function serialize($value, $format, $lang = NULL) {
     $data['value'] = $value;
     switch ($format) {
-      case RdfFieldHandler::RESOURCE:
+      case RdfFieldHandlerInterface::RESOURCE:
         $data['type'] = 'uri';
         break;
 
-      case RdfFieldHandler::NON_TYPE:
+      case RdfFieldHandlerInterface::NON_TYPE:
         $data['type'] = 'literal';
         break;
 
-      case RdfFieldHandler::TRANSLATABLE_LITERAL:
+      case RdfFieldHandlerInterface::TRANSLATABLE_LITERAL:
         $data['lang'] = $lang;
         $data['type'] = 'literal';
         break;

--- a/src/Entity/Query/Sparql/SparqlCondition.php
+++ b/src/Entity/Query/Sparql/SparqlCondition.php
@@ -4,9 +4,9 @@ namespace Drupal\rdf_entity\Entity\Query\Sparql;
 
 use Drupal\Core\Entity\Query\ConditionFundamentals;
 use Drupal\Core\Entity\Query\ConditionInterface;
-use Drupal\Core\Entity\Query\QueryInterface;
 use Drupal\Core\Language\LanguageInterface;
 use Drupal\rdf_entity\RdfFieldHandler;
+use Drupal\rdf_entity\RdfFieldHandlerInterface;
 use Drupal\rdf_entity\RdfGraphHandlerInterface;
 use EasyRdf\Serialiser\Ntriples;
 
@@ -693,7 +693,7 @@ class SparqlCondition extends ConditionFundamentals implements ConditionInterfac
   protected function getLangCode($field, $column = NULL, $default_lang = NULL) {
     $format = $this->fieldHandler->getFieldFormat($this->query->getEntityTypeId(), $field, $column);
     $format = reset($format);
-    if ($format !== RdfFieldHandler::TRANSLATABLE_LITERAL) {
+    if ($format !== RdfFieldHandlerInterface::TRANSLATABLE_LITERAL) {
       return FALSE;
     }
 

--- a/src/Entity/Query/Sparql/SparqlCondition.php
+++ b/src/Entity/Query/Sparql/SparqlCondition.php
@@ -5,7 +5,6 @@ namespace Drupal\rdf_entity\Entity\Query\Sparql;
 use Drupal\Core\Entity\Query\ConditionFundamentals;
 use Drupal\Core\Entity\Query\ConditionInterface;
 use Drupal\Core\Language\LanguageInterface;
-use Drupal\rdf_entity\RdfFieldHandler;
 use Drupal\rdf_entity\RdfFieldHandlerInterface;
 use Drupal\rdf_entity\RdfGraphHandlerInterface;
 use EasyRdf\Serialiser\Ntriples;
@@ -42,7 +41,7 @@ class SparqlCondition extends ConditionFundamentals implements ConditionInterfac
   /**
    * The rdf mapping handler service object.
    *
-   * @var \Drupal\rdf_entity\RdfFieldHandler
+   * @var \Drupal\rdf_entity\RdfFieldHandlerInterface
    */
   protected $fieldHandler;
 
@@ -198,7 +197,7 @@ class SparqlCondition extends ConditionFundamentals implements ConditionInterfac
   /**
    * {@inheritdoc}
    */
-  public function __construct($conjunction, SparqlQueryInterface $query, array $namespaces, RdfGraphHandlerInterface $rdf_graph_handler, RdfFieldHandler $rdf_field_handler) {
+  public function __construct($conjunction, SparqlQueryInterface $query, array $namespaces, RdfGraphHandlerInterface $rdf_graph_handler, RdfFieldHandlerInterface $rdf_field_handler) {
     $conjunction = strtoupper($conjunction);
     parent::__construct($conjunction, $query, $namespaces);
     $this->graphHandler = $rdf_graph_handler;

--- a/src/Entity/Rdf.php
+++ b/src/Entity/Rdf.php
@@ -342,9 +342,11 @@ class Rdf extends ContentEntityBase implements RdfInterface {
   /**
    * {@inheritdoc}
    */
-  public function deleteFromGraph($graph) {
+  public function deleteFromGraph(string $graph_id): void {
     if (!$this->isNew()) {
-      $this->entityManager()->getStorage($this->entityTypeId)->deleteFromGraph($this->id(), $graph);
+      /** @var \Drupal\rdf_entity\RdfEntitySparqlStorageInterface $storage */
+      $storage = $this->entityTypeManager()->getStorage($this->entityTypeId);
+      $storage->deleteFromGraph([$this], $graph_id);
     }
   }
 

--- a/src/Entity/Rdf.php
+++ b/src/Entity/Rdf.php
@@ -250,7 +250,7 @@ class Rdf extends ContentEntityBase implements RdfInterface {
   /**
    * {@inheritdoc}
    */
-  public function setName($name) {
+  public function setName(string $name): RdfInterface {
     $this->set('label', $name);
     return $this;
   }

--- a/src/Entity/RdfEntitySparqlStorage.php
+++ b/src/Entity/RdfEntitySparqlStorage.php
@@ -611,11 +611,16 @@ QUERY;
   /**
    * {@inheritdoc}
    */
-  public function deleteFromGraph(string $entity_id, string $graph_id): void {
-    $entity = $this->load($entity_id, [$graph_id]);
-    if (!empty($entity)) {
-      $this->doDelete([$entity_id => $entity]);
-      $this->resetCache([$entity_id]);
+  public function deleteFromGraph(array $entities, string $graph_id): void {
+    if (!empty($entities)) {
+      $ids = array_map(function (ContentEntityInterface $entity): string {
+        return $entity->id();
+      }, $entities);
+      // Make sure that passed entities are keyed by entity ID and are loaded
+      // only from the requested graph.
+      $entities = $this->loadMultiple($ids, [$graph_id]);
+      $this->doDelete($entities);
+      $this->resetCache(array_keys($entities));
     }
   }
 

--- a/src/Entity/RdfEntitySparqlStorage.php
+++ b/src/Entity/RdfEntitySparqlStorage.php
@@ -74,7 +74,7 @@ class RdfEntitySparqlStorage extends ContentEntityStorageBase implements RdfEnti
   /**
    * The rdf mapping helper service object.
    *
-   * @var \Drupal\rdf_entity\RdfFieldHandler
+   * @var \Drupal\rdf_entity\RdfFieldHandlerInterface
    */
   protected $fieldHandler;
 
@@ -104,12 +104,12 @@ class RdfEntitySparqlStorage extends ContentEntityStorageBase implements RdfEnti
    *   The module handler service.
    * @param \Drupal\rdf_entity\RdfGraphHandlerInterface $rdf_graph_handler
    *   The rdf graph helper service.
-   * @param \Drupal\rdf_entity\RdfFieldHandler $rdf_field_handler
+   * @param \Drupal\rdf_entity\RdfFieldHandlerInterface $rdf_field_handler
    *   The rdf mapping helper service.
    * @param \Drupal\rdf_entity\RdfEntityIdPluginManager $entity_id_plugin_manager
    *   The RDF entity ID generator plugin manager.
    */
-  public function __construct(EntityTypeInterface $entity_type, Connection $sparql, EntityManagerInterface $entity_manager, EntityTypeManagerInterface $entity_type_manager, CacheBackendInterface $cache, LanguageManagerInterface $language_manager, ModuleHandlerInterface $module_handler, RdfGraphHandlerInterface $rdf_graph_handler, RdfFieldHandler $rdf_field_handler, RdfEntityIdPluginManager $entity_id_plugin_manager) {
+  public function __construct(EntityTypeInterface $entity_type, Connection $sparql, EntityManagerInterface $entity_manager, EntityTypeManagerInterface $entity_type_manager, CacheBackendInterface $cache, LanguageManagerInterface $language_manager, ModuleHandlerInterface $module_handler, RdfGraphHandlerInterface $rdf_graph_handler, RdfFieldHandlerInterface $rdf_field_handler, RdfEntityIdPluginManager $entity_id_plugin_manager) {
     parent::__construct($entity_type, $entity_manager, $cache);
     $this->sparql = $sparql;
     $this->languageManager = $language_manager;

--- a/src/Entity/RdfEntitySparqlStorage.php
+++ b/src/Entity/RdfEntitySparqlStorage.php
@@ -24,6 +24,7 @@ use Drupal\rdf_entity\Exception\DuplicatedIdException;
 use Drupal\rdf_entity\RdfEntityIdPluginManager;
 use Drupal\rdf_entity\RdfEntitySparqlStorageInterface;
 use Drupal\rdf_entity\RdfFieldHandler;
+use Drupal\rdf_entity\RdfFieldHandlerInterface;
 use Drupal\rdf_entity\RdfGraphHandlerInterface;
 use EasyRdf\Graph;
 use EasyRdf\Literal;
@@ -818,7 +819,7 @@ QUERY;
           foreach ($column_data as $column => $value) {
             // Filter out empty values or non mapped fields. The id is also
             // excluded as it is not mapped.
-            if ($value === NULL || $value === '' || !$this->fieldHandler->hasFieldPredicate($this->getEntityTypeId(), $field_name, $column, $bundle)) {
+            if ($value === NULL || $value === '' || !$this->fieldHandler->hasFieldPredicate($this->getEntityTypeId(), $bundle, $field_name, $column)) {
               continue;
             }
             $predicate = $this->fieldHandler->getFieldPredicates($this->getEntityTypeId(), $field_name, $column, $bundle);
@@ -968,7 +969,7 @@ QUERY;
       LanguageInterface::LANGCODE_SYSTEM,
     ];
 
-    if ($format == RdfFieldHandler::TRANSLATABLE_LITERAL && !empty($langcode) && !in_array($langcode, $non_languages)) {
+    if ($format == RdfFieldHandlerInterface::TRANSLATABLE_LITERAL && !empty($langcode) && !in_array($langcode, $non_languages)) {
       return $langcode;
     }
 

--- a/src/RdfEntitySparqlStorageInterface.php
+++ b/src/RdfEntitySparqlStorageInterface.php
@@ -78,14 +78,14 @@ interface RdfEntitySparqlStorageInterface extends ContentEntityStorageInterface 
   public function hasGraph(EntityInterface $entity, string $graph_id): bool;
 
   /**
-   * Deletes a the version of the entity stored in a given graph.
+   * Deletes the version of the entities stored in a given graph.
    *
-   * @param string $entity_id
-   *   The ID of the entity to be deleted.
+   * @param \Drupal\Core\Entity\ContentEntityInterface[] $entities
+   *   An array of entity objects to delete.
    * @param string $graph_id
    *   The ID of the graph from where to delete the entity.
    */
-  public function deleteFromGraph(string $entity_id, string $graph_id): void;
+  public function deleteFromGraph(array $entities, string $graph_id): void;
 
   /**
    * Loads one entity.

--- a/src/RdfFieldHandlerInterface.php
+++ b/src/RdfFieldHandlerInterface.php
@@ -1,0 +1,221 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace Drupal\rdf_entity;
+
+/**
+ * Provides a contract for the RDF entity field handler service.
+ */
+interface RdfFieldHandlerInterface {
+
+  /**
+   * Defines the resource type.
+   *
+   * @var string
+   */
+  const RESOURCE = 'resource';
+
+  /**
+   * Defines the translatable literal type.
+   *
+   * @var string
+   */
+  const TRANSLATABLE_LITERAL = 't_literal';
+
+  /**
+   * Defines the literal type.
+   *
+   * @var string
+   */
+  const NON_TYPE = 'literal';
+
+  /**
+   * Returns the SPARQL-to-Drupal mapping array.
+   *
+   * @param string $entity_type_id
+   *   The entity type ID.
+   *
+   * @return array
+   *   The SPARQL-to-Drupal mapping array.
+   */
+  public function getInboundMap(string $entity_type_id): array;
+
+  /**
+   * Returns the predicates for a given field.
+   *
+   * @param string $entity_type_id
+   *   The entity type ID.
+   * @param string $field_name
+   *   The field name.
+   * @param string|null $column_name
+   *   (optional) The column name. If omitted, the main property will be used.
+   * @param string|null $bundle
+   *   (optional) If passed, filter the final array by bundle.
+   *
+   * @return string[]
+   *   An array of predicates.
+   *
+   * @throws \Drupal\rdf_entity\Exception\UnmappedFieldException
+   *    Thrown when a unmapped field is requested.
+   */
+  public function getFieldPredicates(string $entity_type_id, string $field_name, ?string $column_name = NULL, ?string $bundle = NULL): array;
+
+  /**
+   * Returns the format for a given field.
+   *
+   * @param string $entity_type_id
+   *   The entity type ID.
+   * @param string $field_name
+   *   The field name.
+   * @param string|null $column_name
+   *   (optional) The column name. If omitted, the main property will be used.
+   * @param string|null $bundle
+   *   (optional) If passed, filter the final array by bundle.
+   *
+   * @return string[]
+   *   An array of predicates.
+   *
+   * @throws \Exception
+   *    Thrown when a non existing field is requested.
+   */
+  public function getFieldFormat(string $entity_type_id, string $field_name, ?string $column_name = NULL, ?string $bundle = NULL): array;
+
+  /**
+   * Returns the field's main property.
+   *
+   * @param string $entity_type_id
+   *   The entity type machine name.
+   * @param string $field_name
+   *   The field name.
+   *
+   * @return string
+   *   The main property of the field.
+   */
+  public function getFieldMainProperty(string $entity_type_id, string $field_name): string;
+
+  /**
+   * Returns a flat list of property URIs of the given entity type ID.
+   *
+   * @param string $entity_type_id
+   *   The entity type ID.
+   *
+   * @return string[]
+   *   An array of property URIs that belong to the entity type ID.
+   */
+  public function getPropertyListToArray(string $entity_type_id): array;
+
+  /**
+   * Returns if the field has a predicate mapped for the given entity type ID.
+   *
+   * @param string $entity_type_id
+   *   The entity type ID.
+   * @param string $bundle
+   *   The bundle ID.
+   * @param string $field_name
+   *   The field name.
+   * @param string $column_name
+   *   The field column.
+   *
+   * @return bool
+   *   Whether the field is mapped for an entity type ID.
+   */
+  public function hasFieldPredicate(string $entity_type_id, string $bundle, string $field_name, string $column_name): bool;
+
+  /**
+   * Converts a list of bundle IDs to their corresponding URIs.
+   *
+   * @param string $entity_type_id
+   *   The entity type id.
+   * @param string[] $bundles
+   *   An array of bundle machine names.
+   * @param bool $to_resource_uris
+   *   (optional) If true, the IDs will be transformed into resource IDs
+   *   instead. Defaults to FALSE.
+   *
+   * @return string[]
+   *   The altered array.
+   *
+   * @throws \Exception
+   *    Thrown when the bundle does not have a mapping.
+   */
+  public function bundlesToUris(string $entity_type_id, array $bundles, bool $to_resource_uris = FALSE): array;
+
+  /**
+   * Returns the outbound value for the given field.
+   *
+   * This method will be used to convert the value to it's respective SPARQL
+   * format e.g. integer value '1' will be converted to '1^^<xsd:integer>'.
+   *
+   * @param string $entity_type_id
+   *   The entity type ID.
+   * @param string $field_name
+   *   The field name.
+   * @param mixed $value
+   *   The value to convert.
+   * @param string|null $langcode
+   *   (optional) Pass the language code if one exists. This should be NULL if
+   *   the format is not 't_literal'.
+   * @param string|null $column_name
+   *   The column for which to calculate the value. If null, the field's main
+   *   column will be used.
+   * @param string|null $bundle
+   *   (optional) The same field of an entity type might use different value
+   *   formats, depending on how is mapped on each bundle. Pass the bundle, when
+   *   is available, for a better determination of the value format.
+   *
+   * @return mixed
+   *   The calculated value.
+   */
+  public function getOutboundValue(string $entity_type_id, string $field_name, $value, ?string $langcode = NULL, ?string $column_name = NULL, ?string $bundle = NULL);
+
+  /**
+   * Returns the inbound bundle mapping.
+   *
+   * @param string $entity_type_id
+   *   The entity type ID.
+   * @param string $bundle_uri
+   *   The bundle URI.
+   *
+   * @return string[]
+   *   An array of bundles that match the requested bundle.
+   *
+   * @throws \Exception
+   *    Thrown when the bundle is not found.
+   */
+  public function getInboundBundleValue(string $entity_type_id, string $bundle_uri): array;
+
+  /**
+   * Returns the inbound value for the given field.
+   *
+   * @param string $entity_type_id
+   *   The entity type ID.
+   * @param string $field_name
+   *   The field name.
+   * @param mixed $value
+   *   The value to convert.
+   * @param string|null $langcode
+   *   (optional) Pass the language code if one exists. This should be NULL if
+   *   the format is not 't_literal'.
+   * @param string|null $column_name
+   *   (optional) The column name for which to calculate the value. If omitted,
+   *   the field main property will be used.
+   * @param string|null $bundle
+   *   (optional) The same field of an entity type might use different value
+   *   formats, depending on how is mapped on each bundle. Pass the bundle, when
+   *   is available, for a better determination of the value format.
+   *
+   * @return mixed
+   *   The calculated value.
+   */
+  public function getInboundValue(string $entity_type_id, string $field_name, $value, ?string $langcode = NULL, ?string $column_name = NULL, ?string $bundle = NULL);
+
+  /**
+   * Returns an array of available data types.
+   *
+   * @return \Drupal\Component\Render\MarkupInterface[]
+   *   An array of data types.
+   */
+  public static function getSupportedDataTypes(): array;
+
+}

--- a/src/RdfInterface.php
+++ b/src/RdfInterface.php
@@ -27,12 +27,12 @@ interface RdfInterface extends ContentEntityInterface, EntityPublishedInterface,
   /**
    * Sets the name of the rdf entity.
    *
-   * @param int $name
-   *   The rdf entity's name.
+   * @param string $name
+   *   The RDF entity's name.
    *
    * @return $this
    */
-  public function setName($name);
+  public function setName(string $name): self;
 
   /**
    * Removes an entity from the passed graph.

--- a/src/RdfInterface.php
+++ b/src/RdfInterface.php
@@ -40,10 +40,10 @@ interface RdfInterface extends ContentEntityInterface, EntityPublishedInterface,
    * This method does not delete the entity entirely so it skips the delete
    * hooks.
    *
-   * @param string $graph
-   *   The graph machine name.
+   * @param string $graph_id
+   *   The ID of the graph.
    */
-  public function deleteFromGraph($graph);
+  public function deleteFromGraph(string $graph_id): void;
 
   /**
    * Checks if the entity has a specific graph.


### PR DESCRIPTION
Background:

* [Finalize API for creating, overriding, and altering code-defined bundle fields](https://www.drupal.org/project/drupal/issues/2346347#comment-12619089).

## Problem

In order to build the inbound and outbound, maps we're iterating over `EntityFieldManager->getFieldStorageDefinitions($entity_type_id)`. But this method doesn't return fields declared via `hook_entity_bundle_field_info()`. ~Right now it's not clear if this is a Drupal Core bug. I asked a question [here](https://www.drupal.org/project/drupal/issues/2346347#comment-12619089).~ (EDIT: I just got [an answer from Berdir](https://www.drupal.org/project/drupal/issues/2346347#comment-12619574) saying that this is by design)

## Solution

1. Fix `RdfFieldHandler` to account also `hook_entity_bundle_field_info()` defined fields. Iterate over `EntityFieldManager->getFieldDefinition($entity_type_id, $bundle)`, for each bundle. Drop iteration on `EntityFieldManager->getFieldStorageDefinitions($entity_type_id)`.
1. Cleanup and modernise the service. I need this in order to understand what's going on there and next tasks are helping a lor:
* Add a service contract.
* Add strict typing.
* Improve type hinting.
* Improve documentation. Especially, make clear the structure of outbound and inbound maps.