### PR TITLE
Fix endless loop when updating URL aliases pointing to orphaned entities

### DIFF
--- a/src/Plugin/pathauto/AliasType/RdfEntityAliasType.php
+++ b/src/Plugin/pathauto/AliasType/RdfEntityAliasType.php
@@ -90,12 +90,27 @@ class RdfEntityAliasType extends EntityAliasTypeBase implements ContainerFactory
     $query->range($context['sandbox']['count'], 25);
     $ids = $query->execute();
 
-    $updates = $this->bulkUpdate($ids);
-    $context['sandbox']['count'] += count($ids);
-    $context['results']['updates'] += $updates;
-    $context['message'] = $this->t('Updated alias for Rdf entity @id.', ['@id' => end($ids)]);
+    $context['sandbox']['count'] = min($context['sandbox']['count'] + 25, $context['sandbox']['total']);
 
-    if ($context['sandbox']['count'] != $context['sandbox']['total']) {
+    $progress = sprintf('%.2f%%', $context['sandbox']['count'] / $context['sandbox']['total'] * 100);
+
+    if (!empty($ids)) {
+      $updates = $this->bulkUpdate($ids);
+      $context['message'] = $this->t('[@progress] Updated alias for Rdf entity @id.', [
+        '@progress' => $progress,
+        '@id' => end($ids),
+      ]);
+    }
+    else {
+      $updates = 0;
+      $context['message'] = $this->t('[@progress] No Rdf entities returned from database. Requested entities are possibly orphaned.', [
+        '@progress' => $progress,
+      ]);
+    }
+
+    $context['results']['updates'] += $updates;
+
+    if ($context['sandbox']['count'] < $context['sandbox']['total']) {
       $context['finished'] = $context['sandbox']['count'] / $context['sandbox']['total'];
     }
   }

--- a/src/Plugin/pathauto/AliasType/RdfEntityAliasType.php
+++ b/src/Plugin/pathauto/AliasType/RdfEntityAliasType.php
@@ -96,7 +96,7 @@ class RdfEntityAliasType extends EntityAliasTypeBase implements ContainerFactory
 
     if (!empty($ids)) {
       $updates = $this->bulkUpdate($ids);
-      $context['message'] = $this->t('[@progress] Updated alias for Rdf entity @id.', [
+      $context['message'] = $this->t('[@progress] Processed Rdf entity @id.', [
         '@progress' => $progress,
         '@id' => end($ids),
       ]);


### PR DESCRIPTION
When there are URL aliases present in the database that reference orphaned RDF entities then the batch process gets stuck in an endless loop. This is caused by the counter being incremented with the number of entities returned from the database, rather than with the number of aliases that are attempted to be generated. If there is an orphaned alias present then the count will never reach the total and the batch process will loop endlessly.

This also fixes incomplete messages being shown when trying to display the entity IDs of orphaned entities.