### PR TITLE
Docblock for RdfEntityViewBuilder is copied from TermViewBuilder

### DIFF
--- a/src/RdfEntityViewBuilder.php
+++ b/src/RdfEntityViewBuilder.php
@@ -7,7 +7,7 @@ use Drupal\Core\Entity\EntityInterface;
 use Drupal\Core\Entity\EntityViewBuilder;
 
 /**
- * Render controller for taxonomy terms.
+ * Render controller for RDF entities.
  */
 class RdfEntityViewBuilder extends EntityViewBuilder {
 


### PR DESCRIPTION
The `RdfEntityViewBuilder` seems to be inspired on the `TermViewBuilder` but it was forgotten to update the class docblock, it still mentions that this is about taxonomy terms.