### PR TITLE
ISAICP-3899: Do not vary lists by user.

### DIFF
--- a/src/Entity/Rdf.php
+++ b/src/Entity/Rdf.php
@@ -34,7 +34,6 @@ use Drupal\user\UserInterface;
  *     },
  *     "access" = "Drupal\rdf_entity\RdfAccessControlHandler",
  *   },
- *   list_cache_contexts = { "user" },
  *   base_table = null,
  *   admin_permission = "administer rdf entity",
  *   fieldable = TRUE,


### PR DESCRIPTION
There is no reason to assume that listings of RDF entities are going to be different depending on the user viewing it. Having this causes any listing containing one or more RDF entities to be uncacheable.