### PR TITLE
Deprecate the 'edit' operation for entity access checks

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -38,11 +38,6 @@ before_install:
   - mkdir -p ${SITE_DIR}/web/modules
   - cd ${SITE_DIR}
 
-  ### PHP_CodeSniffer only.
-
-  # We only need the PHP Code Sniffer (and the Drupal coder).
-  - test ${TEST} == "PHP_CodeSniffer" && composer require drupal/coder || true
-
   ### PHPUnit only (till the end).
 
   # Deploy the codebase.

--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,8 @@
     "drupal/sparql_entity_storage": "dev-8.x-1.x"
   },
   "require-dev": {
-    "minimaxir/big-list-of-naughty-strings": "dev-master"
+    "minimaxir/big-list-of-naughty-strings": "dev-master",
+    "drupal/coder": "^8.3"
   },
   "repositories": [
     {

--- a/phpcs-ruleset.xml.dist
+++ b/phpcs-ruleset.xml.dist
@@ -1,0 +1,27 @@
+<?xml version="1.0"?>
+<!-- PHP_CodeSniffer standard for Drupal modules. -->
+<!-- See http://pear.php.net/manual/en/package.php.php-codesniffer.annotated-ruleset.php -->
+<ruleset name="Drupal Module">
+    <description>Drupal coding standard for contributed modules</description>
+
+    <!-- Exclude unsupported file types. -->
+    <exclude-pattern>*.gif</exclude-pattern>
+    <exclude-pattern>*.less</exclude-pattern>
+    <exclude-pattern>*.png</exclude-pattern>
+
+    <!-- Minified files don't have to comply with coding standards. -->
+    <exclude-pattern>*.min.css</exclude-pattern>
+    <exclude-pattern>*.min.js</exclude-pattern>
+
+    <rule ref="./vendor/drupal/coder/coder_sniffer/Drupal">
+        <!-- URLs in deprecation messages point to Github rather than drupal.org. -->
+        <exclude name="Drupal.Semantics.FunctionTriggerError.TriggerErrorSeeUrlFormat" />
+        <!-- Deprecation versions are allowed to include beta versions. -->
+        <exclude name="Drupal.Semantics.FunctionTriggerError.TriggerErrorVersion" />
+    </rule>
+    <rule ref="./vendor/drupal/coder/coder_sniffer/DrupalPractice">
+        <exclude name="DrupalPractice.Objects.GlobalFunction.GlobalFunction" />
+        <exclude name="DrupalPractice.Objects.GlobalDrupal.GlobalDrupal" />
+        <exclude name="DrupalPractice.InfoFiles.NamespacedDependency.NonNamespaced" />
+    </rule>
+</ruleset>

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ruleset name="pbm_default">
+  <description>Default PHP CodeSniffer configuration for RDF Entity.</description>
+  <rule ref="phpcs-ruleset.xml.dist"/>
+  <arg name="extensions" value="php,inc,module,install,info,test,profile,theme,css,js"/>
+  <arg name="report" value="full"/>
+  <arg value="p"/>
+  <file>.</file>
+  <exclude-pattern>./vendor</exclude-pattern>
+</ruleset>

--- a/src/RdfAccessControlHandler.php
+++ b/src/RdfAccessControlHandler.php
@@ -19,6 +19,11 @@ class RdfAccessControlHandler extends EntityAccessControlHandler {
    * $operation as defined in the routing.yml file.
    */
   protected function checkAccess(EntityInterface $entity, $operation, AccountInterface $account) {
+    if ($operation === 'edit') {
+      trigger_error('Passing in the "edit" operation to RdfAccessControlHandler::checkAccess() is deprecated in RDF Entity 8.x-1.0-alpha19 and will be removed before 8.x-1.0-beta1. Pass in the "update" operation instead.', E_USER_DEPRECATED);
+      $operation = 'update';
+    }
+
     if (!$entity instanceof RdfInterface) {
       throw new \Exception('Can only handle access of Rdf entity instances.');
     }
@@ -34,7 +39,6 @@ class RdfAccessControlHandler extends EntityAccessControlHandler {
         return AccessResult::allowedIfHasPermission($account, 'view rdf entity');
 
       case 'update':
-      case 'edit':
         if ($account->hasPermission('edit ' . $entity_bundle . ' rdf entity')) {
           return AccessResult::allowed();
         }

--- a/src/RdfAccessControlHandler.php
+++ b/src/RdfAccessControlHandler.php
@@ -20,7 +20,7 @@ class RdfAccessControlHandler extends EntityAccessControlHandler {
    */
   protected function checkAccess(EntityInterface $entity, $operation, AccountInterface $account) {
     if ($operation === 'edit') {
-      trigger_error('Passing in the "edit" operation to RdfAccessControlHandler::checkAccess() is deprecated in RDF Entity 8.x-1.0-alpha19 and will be removed before 8.x-1.0-beta1. Pass in the "update" operation instead.', E_USER_DEPRECATED);
+      trigger_error('Passing in the "edit" operation to RdfAccessControlHandler::checkAccess() is deprecated in RDF Entity 8.x-1.0-alpha19 and will be removed before 8.x-1.0-beta1. Pass in the "update" operation instead. See https://github.com/ec-europa/rdf_entity/issues/110', E_USER_DEPRECATED);
       $operation = 'update';
     }
 

--- a/tests/travis-ci/scripts/run_tests
+++ b/tests/travis-ci/scripts/run_tests
@@ -2,9 +2,8 @@
 
 case "$1" in
     PHP_CodeSniffer)
-        cd ${SITE_DIR}
-        ./vendor/bin/phpcs --config-set installed_paths ../../drupal/coder/coder_sniffer
-        ./vendor/bin/phpcs --standard=Drupal --extensions=php,module,inc,install,test,profile,theme,css,info,txt --ignore='*.md' ${TRAVIS_BUILD_DIR}
+        cd ${TRAVIS_BUILD_DIR}
+        ./vendor/bin/phpcs
         exit $?
         ;;
     8.*.x)

--- a/tests/travis-ci/scripts/run_tests
+++ b/tests/travis-ci/scripts/run_tests
@@ -3,6 +3,7 @@
 case "$1" in
     PHP_CodeSniffer)
         cd ${TRAVIS_BUILD_DIR}
+        composer install
         ./vendor/bin/phpcs
         exit $?
         ;;


### PR DESCRIPTION
The RDF Entity module supports both the `edit` and `update` operations for entity access checks, but core only supports `update`. We should not handle `edit` at all, this is an operation that is only used for checking field access, never for entity access.

Let's for now deprecate it so we can alert our users to update their code. In a future version we can remove it.