### PR TITLE
Proper own any permissions

### DIFF
--- a/rdf_entity.routing.yml
+++ b/rdf_entity.routing.yml
@@ -30,14 +30,6 @@ rdf_entity.rdf_add:
   requirements:
     _entity_create_access: 'rdf_entity:{rdf_type}'
 
-entity.rdf_entity.edit_form:
-  path: '/rdf_entity/{rdf_entity}/edit'
-  defaults:
-    _entity_form: rdf_entity.edit
-    _title: 'Edit Rdf'
-  requirements:
-    _entity_access: 'rdf_entity.edit'
-
 entity.rdf_entity.delete_form:
   path: '/rdf_entity/{rdf_entity}/delete'
   defaults:

--- a/rdf_entity.routing.yml
+++ b/rdf_entity.routing.yml
@@ -30,6 +30,14 @@ rdf_entity.rdf_add:
   requirements:
     _entity_create_access: 'rdf_entity:{rdf_type}'
 
+entity.rdf_entity.edit_form:
+  path: '/rdf_entity/{rdf_entity}/edit'
+  defaults:
+    _entity_form: rdf_entity.edit
+    _title: 'Edit Rdf'
+  requirements:
+    _entity_access: 'rdf_entity.update'
+
 entity.rdf_entity.delete_form:
   path: '/rdf_entity/{rdf_entity}/delete'
   defaults:

--- a/src/RdfAccessControlHandler.php
+++ b/src/RdfAccessControlHandler.php
@@ -19,11 +19,6 @@ class RdfAccessControlHandler extends EntityAccessControlHandler {
    * $operation as defined in the routing.yml file.
    */
   protected function checkAccess(EntityInterface $entity, $operation, AccountInterface $account) {
-    if ($operation === 'edit') {
-      trigger_error('Passing in the "edit" operation to RdfAccessControlHandler::checkAccess() is deprecated in RDF Entity 8.x-1.0-alpha19 and will be removed before 8.x-1.0-beta1. Pass in the "update" operation instead.', E_USER_DEPRECATED);
-      $operation = 'update';
-    }
-
     if (!$entity instanceof RdfInterface) {
       throw new \Exception('Can only handle access of Rdf entity instances.');
     }
@@ -39,18 +34,18 @@ class RdfAccessControlHandler extends EntityAccessControlHandler {
         return AccessResult::allowedIfHasPermission($account, 'view rdf entity');
 
       case 'update':
-        if ($account->hasPermission('update ' . $entity_bundle . ' rdf entity')) {
+        if ($account->hasPermission("edit any {$entity_bundle} rdf entity")) {
           return AccessResult::allowed();
         }
 
-        return AccessResult::allowedIf($is_owner && $account->hasPermission('edit own ' . $entity_bundle . ' rdf entity'));
+        return AccessResult::allowedIf($is_owner && $account->hasPermission("edit own {$entity_bundle} rdf entity"));
 
       case 'delete':
-        if ($account->hasPermission('delete ' . $entity_bundle . ' rdf entity')) {
+        if ($account->hasPermission("delete any {$entity_bundle} rdf entity")) {
           return AccessResult::allowed();
         }
 
-        return AccessResult::allowedIf($is_owner && $account->hasPermission('delete own ' . $entity_bundle . ' rdf entity'));
+        return AccessResult::allowedIf($is_owner && $account->hasPermission("delete own {$entity_bundle} rdf entity"));
     }
 
     return AccessResult::neutral();

--- a/src/RdfAccessControlHandler.php
+++ b/src/RdfAccessControlHandler.php
@@ -19,6 +19,11 @@ class RdfAccessControlHandler extends EntityAccessControlHandler {
    * $operation as defined in the routing.yml file.
    */
   protected function checkAccess(EntityInterface $entity, $operation, AccountInterface $account) {
+    if ($operation === 'edit') {
+      trigger_error('Passing in the "edit" operation to RdfAccessControlHandler::checkAccess() is deprecated in RDF Entity 8.x-1.0-alpha19 and will be removed before 8.x-1.0-beta1. Pass in the "update" operation instead.', E_USER_DEPRECATED);
+      $operation = 'update';
+    }
+
     if (!$entity instanceof RdfInterface) {
       throw new \Exception('Can only handle access of Rdf entity instances.');
     }
@@ -34,7 +39,6 @@ class RdfAccessControlHandler extends EntityAccessControlHandler {
         return AccessResult::allowedIfHasPermission($account, 'view rdf entity');
 
       case 'update':
-      case 'edit':
         if ($account->hasPermission('edit ' . $entity_bundle . ' rdf entity')) {
           return AccessResult::allowed();
         }

--- a/src/RdfAccessControlHandler.php
+++ b/src/RdfAccessControlHandler.php
@@ -39,7 +39,7 @@ class RdfAccessControlHandler extends EntityAccessControlHandler {
         return AccessResult::allowedIfHasPermission($account, 'view rdf entity');
 
       case 'update':
-        if ($account->hasPermission('edit ' . $entity_bundle . ' rdf entity')) {
+        if ($account->hasPermission('update ' . $entity_bundle . ' rdf entity')) {
           return AccessResult::allowed();
         }
 


### PR DESCRIPTION
This is a followup of https://github.com/ec-europa/rdf_entity/pull/107 where the idea of changing strings was rejected. This splits the work that is reverted in that PR.

The idea is that the 'edit' operation is removed. We can now also fix the permission strings that currently have the form of
`edit $bundle rdf entity` to edit any rdf entity and
`edit own $bundle rdf entity` to edit the owned entity.
The same applies for the delete operation as well.