### PR TITLE
Test on currently supported PHP versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -32,6 +32,10 @@ matrix:
       env: TEST=PHP_CodeSniffer
     - php: '7.4'
       env: TEST=PHP_CodeSniffer
+    - php: '7.4'
+      env: TEST=8.6.x
+    - php: '7.4'
+      env: TEST=8.7.x
   allow_failures:
     - php: '7.4'
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,9 @@
 language: php
 
 php:
-  - '7.1'
   - '7.2'
   - '7.3'
+  - '7.4'
 
 sudo: required
 
@@ -28,10 +28,12 @@ env:
 matrix:
   fast_finish: true
   exclude:
-    - php: '7.2'
-      env: TEST=PHP_CodeSniffer
     - php: '7.3'
       env: TEST=PHP_CodeSniffer
+    - php: '7.4'
+      env: TEST=PHP_CodeSniffer
+  allow_failures:
+    - php: '7.4'
 
 before_install:
   - composer --verbose self-update


### PR DESCRIPTION
PHP 7.4 has been released but is not fully supported in older versions of Drupal. PHP 7.1 has been deprecated.