### PR TITLE
Path alias handling has changed in Drupal 8.8.0.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,9 +21,8 @@ env:
     - SITE_DIR="$HOME/build/testing_site"
   matrix:
     - TEST=PHP_CodeSniffer
-    - TEST=8.6.x
-    - TEST=8.7.x
     - TEST=8.8.x
+    - TEST=8.9.x
 
 matrix:
   fast_finish: true
@@ -32,10 +31,6 @@ matrix:
       env: TEST=PHP_CodeSniffer
     - php: '7.4'
       env: TEST=PHP_CodeSniffer
-    - php: '7.4'
-      env: TEST=8.6.x
-    - php: '7.4'
-      env: TEST=8.7.x
   allow_failures:
     - php: '7.4'
 

--- a/composer.json
+++ b/composer.json
@@ -11,11 +11,13 @@
   "minimum-stability": "dev",
   "require": {
     "php": ">=7.1",
+    "drupal/core": "~8.8",
     "drupal/sparql_entity_storage": "dev-8.x-1.x"
   },
   "require-dev": {
     "minimaxir/big-list-of-naughty-strings": "dev-master",
-    "drupal/coder": "^8.3"
+    "drupal/coder": "^8.3",
+    "easyrdf/easyrdf": "0.10.0-alpha.1 as 0.9.2"
   },
   "repositories": [
     {

--- a/rdf_entity.info.yml
+++ b/rdf_entity.info.yml
@@ -6,5 +6,5 @@ description: 'Provides an entity that uses the SPARQL storage.'
 package: Custom
 
 dependencies:
-  - drupal:options
+  - drupal:options (>=8.8)
   - sparql_entity_storage


### PR DESCRIPTION
We require this as the minimum version now.

Drupal 8.6 has been deprecated and Drupal 8.7 is in security-only support now, but since we are still in alpha we do not support security releases. Our users that are still on Drupal 8.7 can keep using the previous release and are expected to apply any security patches manually.