### PR TITLE
Rdf::hasGraph breaks if the entity is new

### DIFF
--- a/src/Entity/Rdf.php
+++ b/src/Entity/Rdf.php
@@ -359,6 +359,9 @@ class Rdf extends ContentEntityBase implements RdfInterface {
    * {@inheritdoc}
    */
   public function hasGraph($graph) {
+    if ($this->isNew()) {
+      return FALSE;
+    }
     return $this->entityTypeManager()->getStorage($this->getEntityTypeId())->hasGraph($this, $graph);
   }
 

--- a/src/RdfInterface.php
+++ b/src/RdfInterface.php
@@ -48,6 +48,8 @@ interface RdfInterface extends ContentEntityInterface, EntityPublishedInterface,
   /**
    * Checks if the entity has a specific graph.
    *
+   * Returns false, if the entity is new.
+   *
    * @param string $graph
    *   The graph to be checked ('draft', etc).
    *

--- a/tests/src/Kernel/RdfEntityTest.php
+++ b/tests/src/Kernel/RdfEntityTest.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace Drupal\Tests\rdf_entity\Kernel;
+
+use Drupal\rdf_entity\Entity\Rdf;
+
+/**
+ * Tests for the RDF entity class.
+ *
+ * @coversDefaultClass \Drupal\rdf_entity\Entity\Rdf
+ */
+class RdfEntityTest extends RdfKernelTestBase {
+
+  /**
+   * Covers ::hasGraph
+   */
+  public function testHasGraph() {
+    $rdf_entity = Rdf::create([
+      'rid' => 'dummy',
+      'label' => $this->randomMachineName()
+    ]);
+    $this->assertFalse($rdf_entity->hasGraph('default'));
+
+    $rdf_entity->save();
+    $this->assertTrue($rdf_entity->hasGraph('default'));
+    $this->assertFalse($rdf_entity->hasGraph('draft'));
+
+    $rdf_entity->set('graph', 'draft')->save();
+    $this->assertTrue($rdf_entity->hasGraph('default'));
+    $this->assertTrue($rdf_entity->hasGraph('draft'));
+    $rdf_entity->deleteFromGraph('default');
+    $this->assertFalse($rdf_entity->hasGraph('default'));
+    $this->assertTrue($rdf_entity->hasGraph('draft'));
+  }
+
+}


### PR DESCRIPTION
The method `\Drupal\rdf_entity\Entity\Rdf::hasGraph` checks if the entity has a copy of itself into the specified graph.
However, the method fails if the entity is new and this method is called due to the lack of ID.
Even if there was an ID (like manually set before the entity is saved) it wouldn't make sense to run a query in the database since we know that it is new.

I am providing a test for the method itself that proves the issue and a fix.