### PR TITLE
Remove deprecated UrlGeneratorTrait.

### DIFF
--- a/src/RdfPermissions.php
+++ b/src/RdfPermissions.php
@@ -1,26 +1,26 @@
 <?php
 
+declare(strict_types = 1);
+
 namespace Drupal\rdf_entity;
 
-use Drupal\Core\Routing\UrlGeneratorTrait;
 use Drupal\Core\StringTranslation\StringTranslationTrait;
 use Drupal\rdf_entity\Entity\RdfEntityType;
 
 /**
- * Provides dynamic permissions for RdfEntities of different types.
+ * Provides dynamic permissions for RDF entities of different types.
  */
 class RdfPermissions {
 
   use StringTranslationTrait;
-  use UrlGeneratorTrait;
 
   /**
    * Returns an array of node type permissions.
    *
    * @return array
-   *   The RdfEntity type permissions.
+   *   The RDF entity type permissions.
    */
-  public function rdfTypePermissions() {
+  public function rdfTypePermissions(): array {
     $perms = [];
     // Generate node permissions for all node types.
     foreach (RdfEntityType::loadMultiple() as $type) {
@@ -34,12 +34,12 @@ class RdfPermissions {
    * Returns a list of node permissions for a given node type.
    *
    * @param \Drupal\rdf_entity\Entity\RdfEntityType $type
-   *   The RdfEntity type.
+   *   The RDF entity type.
    *
    * @return array
    *   An associative array of permission names and descriptions.
    */
-  protected function buildPermissions(RdfEntityType $type) {
+  protected function buildPermissions(RdfEntityType $type): array {
     $type_id = $type->id();
     $type_params = ['%type_name' => $type->label()];
 


### PR DESCRIPTION
This PR is fixing the following deprecation warning:

```
 ------ ------------------------------------------------------------------------------------------------------------
  Line   src/RdfPermissions.php
 ------ ------------------------------------------------------------------------------------------------------------
  15     Usage of deprecated trait Drupal\Core\Routing\UrlGeneratorTrait in class Drupal\rdf_entity\RdfPermissions:
         in drupal:8.0.0 and is removed from drupal:9.0.0.
         Use \Drupal\Core\Url instead.
 ------ ------------------------------------------------------------------------------------------------------------
```

It turns out the deprecated trait is no longer used, so it can simply be removed.

I also made some minor modernizations to the class.