### PR TITLE
The connection with the Sparql database should be set up in ::bootEnvironment()

### DIFF
--- a/tests/src/Kernel/RdfKernelTestBase.php
+++ b/tests/src/Kernel/RdfKernelTestBase.php
@@ -29,9 +29,16 @@ abstract class RdfKernelTestBase extends EntityKernelTestBase {
   /**
    * {@inheritdoc}
    */
+  protected function bootEnvironment() {
+    parent::bootEnvironment();
+    $this->setUpSparql();
+  }
+
+  /**
+   * {@inheritdoc}
+   */
   protected function setUp() {
     parent::setUp();
-    $this->setUpSparql();
     $this->installConfig([
       'rdf_entity',
       'rdf_draft',


### PR DESCRIPTION
Currently it is being set up after calling `parent::setUp()` but this is too late since at this point the container has already been built, and services might be accessing storage. We should call this instead in `::bootEnvironment()`, the method in which the regular SQL storage is also set up.