### PR TITLE
Replace deprecated method EntityInterface::urlInfo()

### DIFF
--- a/src/Form/RdfTypeForm.php
+++ b/src/Form/RdfTypeForm.php
@@ -94,13 +94,13 @@ class RdfTypeForm extends BundleEntityFormBase {
       case SAVED_NEW:
         drupal_set_message($this->t('Created new rdf type %name.', ['%name' => $rdf_type->label()]));
         $this->logger('taxonomy')->notice('Created new rdf type %name.', ['%name' => $rdf_type->label(), 'link' => $edit_link]);
-        $form_state->setRedirectUrl($rdf_type->urlInfo('overview-form'));
+        $form_state->setRedirectUrl($rdf_type->toUrl('overview-form'));
         break;
 
       case SAVED_UPDATED:
         drupal_set_message($this->t('Updated rdf type %name.', ['%name' => $rdf_type->label()]));
         $this->logger('taxonomy')->notice('Updated rdf type %name.', ['%name' => $rdf_type->label(), 'link' => $edit_link]);
-        $form_state->setRedirectUrl($rdf_type->urlInfo('collection'));
+        $form_state->setRedirectUrl($rdf_type->toUrl('collection'));
         break;
     }
 


### PR DESCRIPTION
Fixes following deprecation warning:

```
 ------ ----------------------------------------------------------------------------------
  Line   src/Form/RdfTypeForm.php
 ------ ----------------------------------------------------------------------------------
  97     Call to deprecated method urlInfo() of class Drupal\Core\Entity\EntityInterface:
         in drupal:8.0.0 and is removed from drupal:9.0.0.
         Use \Drupal\Core\Entity\EntityInterface::toUrl() instead.
  103    Call to deprecated method urlInfo() of class Drupal\Core\Entity\EntityInterface:
         in drupal:8.0.0 and is removed from drupal:9.0.0.
         Use \Drupal\Core\Entity\EntityInterface::toUrl() instead.
 ------ ----------------------------------------------------------------------------------
```