### PR TITLE
RDF Entity depends on the SparqlEntityNormalizer class which is avail…

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
   "minimum-stability": "alpha",
   "require": {
     "php": ">=7.1",
-    "drupal/sparql_entity_storage": "^1.0"
+    "drupal/sparql_entity_storage": "^1.0-alpha4"
   },
   "require-dev": {
     "minimaxir/big-list-of-naughty-strings": "dev-master",

--- a/rdf_entity.info.yml
+++ b/rdf_entity.info.yml
@@ -6,4 +6,4 @@ package: Custom
 
 dependencies:
   - drupal:options
-  - sparql_entity_storage:sparql_entity_storage
+  - sparql_entity_storage:sparql_entity_storage (>=8.x-1.0-alpha4)


### PR DESCRIPTION
…able in Sparql Entity Storage 1.0.0-alpha4 and higher.

Fixes #132