### PR TITLE
RDF taxonomy term 'tid' base field is losing some definition entries

### DIFF
--- a/modules/rdf_taxonomy/rdf_taxonomy.module
+++ b/modules/rdf_taxonomy/rdf_taxonomy.module
@@ -52,7 +52,7 @@ function rdf_taxonomy_entity_base_field_info_alter(array &$fields, EntityTypeInt
     ->setTargetBundle($original_tid->getTargetBundle())
     ->setLabel($original_tid->getLabel())
     ->setDescription($original_tid->getDescription())
-    ->setProvider($original_tid->getProvider())
+    ->setProvider('rdf_taxonomy')
     ->setReadOnly($original_tid->isReadOnly());
 }
 

--- a/modules/rdf_taxonomy/rdf_taxonomy.module
+++ b/modules/rdf_taxonomy/rdf_taxonomy.module
@@ -37,16 +37,23 @@ function rdf_taxonomy_entity_type_alter(array &$entity_types) {
 /**
  * Implements hook_entity_base_field_info_alter().
  */
-function rdf_taxonomy_entity_base_field_info_alter(&$fields, EntityTypeInterface $entity_type) {
+function rdf_taxonomy_entity_base_field_info_alter(array &$fields, EntityTypeInterface $entity_type): void {
   if ($entity_type->id() != 'taxonomy_term') {
     return;
   }
+
+  /** @var \Drupal\Core\Field\BaseFieldDefinition $original_tid */
+  $original_tid = $fields['tid'];
+
   // Change the tid type to string (RDF uri).
   $fields['tid'] = BaseFieldDefinition::create('string')
-    ->setLabel(t('Term ID'))
-    ->setDescription(t('The term ID.'))
-    ->setReadOnly(TRUE);
-  $fields['tid']->setTargetEntityTypeId('taxonomy_term');
+    ->setName($original_tid->getName())
+    ->setTargetEntityTypeId($original_tid->getTargetEntityTypeId())
+    ->setTargetBundle($original_tid->getTargetBundle())
+    ->setLabel($original_tid->getLabel())
+    ->setDescription($original_tid->getDescription())
+    ->setProvider($original_tid->getProvider())
+    ->setReadOnly($original_tid->isReadOnly());
 }
 
 /**


### PR DESCRIPTION
We replace the `tid` base field definition with our own because we need a URI rather than an integer, in `rdf_taxonomy_entity_base_field_info_alter()`. But in this stage, the field definition is already completed, the provider and other automated properties were already added. With our implementation, we remove some field definitions, the most notable is `provider`. This causes issues in 3rd party code. An example is Search API, where the field provider is added as dependency to the SAPI index config entity. As the field provider is missing we get there something like:

```yaml
  tid:
    label: 'Term ID'
    datasource_id: 'entity:taxonomy_term'
    property_path: tid
    type: string
    dependencies:
      module:
        - null
```

